### PR TITLE
add support for psqlextra extensions in reset_db

### DIFF
--- a/django_extensions/management/commands/reset_db.py
+++ b/django_extensions/management/commands/reset_db.py
@@ -112,6 +112,7 @@ Type 'yes' to continue, or 'no' to cancel: """ % (database_name,))
             'django.db.backends.postgresql',
             'django.db.backends.postgresql_psycopg2',
             'django.db.backends.postgis',
+            'psqlextra.backend',
         ))
 
         if engine in SQLITE_ENGINES:


### PR DESCRIPTION
This attempts to suport the django-postgres-extra library wich is also a valid postgresq engine.